### PR TITLE
Update composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Plugin to help automate weekly type metrics and posts.",
     "type": "wordpress-plugin",
     "require": {
-        "composer/installers": "~1.0",
+        "composer/installers": "^2.0",
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.0",
         "vlucas/phpdotenv": "^5.5"


### PR DESCRIPTION
v1.0 has some issues with later versions of PHP, so let's use the newer maor version.