### PR TITLE
Update Composer coding standards and order

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,52 @@
 {
-    "name": "automattic/metrics-poster",
-    "description": "Plugin to help automate weekly type metrics and posts.",
-    "type": "wordpress-plugin",
-    "require": {
-        "composer/installers": "^2.0",
-        "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.0",
-        "vlucas/phpdotenv": "^5.5"
-    },
-    "require-dev": {
+	"name": "automattic/metrics-poster",
+	"description": "Plugin to help automate weekly type metrics and posts.",
+	"license": "mit",
+	"type": "wordpress-plugin",
+	"authors": [
+		{
+			"name": "Omar Serrano",
+			"email": "omar.serrano@automattic.com"
+		}
+	],
+	"require": {
+		"php": "^8.1",
+		"composer/installers": "^2.0",
+		"guzzlehttp/guzzle": "^7.0",
+		"vlucas/phpdotenv": "^5.5"
+	},
+	"require-dev": {
 		"automattic/vipwpcs": "^3",
+		"brain/monkey": "^2.6",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"phpunit/phpunit": "^9",
-		"yoast/phpunit-polyfills": "^2.0",
-        "brain/monkey": "^2.6"
+		"yoast/phpunit-polyfills": "^2.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"MetricPoster\\Tests\\": "tests/"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"scripts": {
+		"cbf": [
+			"@php ./vendor/bin/phpcbf"
+		],
 		"coverage": [
 			"@php ./vendor/bin/phpunit --coverage-html ./build/coverage-html"
 		],
 		"coverage-ci": [
 			"@php ./vendor/bin/phpunit"
-		],
-		"cbf": [
-			"@php ./vendor/bin/phpcbf"
 		],
 		"cs": [
 			"@php ./vendor/bin/phpcs"
@@ -40,28 +63,5 @@
 		"test": [
 			"@php ./vendor/bin/phpunit --testsuite WP_Tests"
 		]
-	},
-	"config": {
-		"allow-plugins": {
-			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
-	},
-    "license": "mit",
-	"autoload": {
-		"classmap": [
-			"src/"
-		]
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"MetricPoster\\Tests\\": "tests/"
-		}
-	},
-    "authors": [
-        {
-            "name": "Omar Serrano",
-            "email": "omar.serrano@automattic.com"
-        }
-    ]
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "032d8358684cf86a51b30bdeef2b0101",
+    "content-hash": "1cf0a3c80feffac8bc53beb7f43f9957",
     "packages": [
         {
             "name": "composer/installers",
@@ -3980,12 +3980,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
- Add `.editorconfig`, to help IDEs keep consistent indentation, for instance.
- Fix indentation in Composer.
- Normalizing the Composer file with composer-normalize.


